### PR TITLE
Change module interface to conform common style

### DIFF
--- a/gulp/test.js
+++ b/gulp/test.js
@@ -1,8 +1,7 @@
 'use strict';
 
 var insert = require('gulp-insert');
-var diff = require('..').diff;
-var diffReporter = require('..').reporter;
+var diff = require('..');
 
 var expected = [{
   value: 'HELLO\nWORLD\n',
@@ -41,7 +40,7 @@ module.exports = function(gulp) {
           gulp.fail = true;
         }
       })
-      .pipe(diffReporter());
+      .pipe(diff.reporter());
   });
 
   gulp.task('diff-none', function() {
@@ -57,6 +56,6 @@ module.exports = function(gulp) {
           gulp.fail = true;
         }
       })
-      .pipe(diffReporter());
+      .pipe(diff.reporter());
   });
 };

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var clc = require('cli-color');
 var fs = require('fs');
 var path = require('path');
 
-exports.diff = function diff(dest) {
+var diff = function diff(dest) {
   return through2.obj(function(file, enc, cb) {
     if (file.isNull()) {
       return cb(null, file);
@@ -24,7 +24,6 @@ exports.diff = function diff(dest) {
           if (contents !== String(file.contents)) {
             try {
               file.diff = diffLines(fs.readFileSync(compareFile, 'utf8'), String(file.contents));
-
             } catch (err) {
               cb('failed to diff file: ' + err.message);
             }
@@ -42,7 +41,7 @@ exports.diff = function diff(dest) {
   });
 };
 
-exports.reporter = function reporter(opts) {
+var reporter = function reporter(opts) {
   opts = opts || {};
   return through2.obj(function(file, enc, cb) {
     if (file.diff && Object.keys(file.diff).length) {
@@ -69,3 +68,6 @@ function colorLine(ln) {
   }
   return 'blackBright';
 }
+
+module.exports = diff;
+module.exports.reporter = reporter;


### PR DESCRIPTION
I see it's common pattern among other gulp plugins to do something,

``` js
var diff = require('gulp-diff'):

gulp.task('smth', function () {
  gult.src('/a').pipe(diff('/b)).pipe(diff.reporter());
});
```

instead of

``` js
var diff = require('gulp-diff').diff:
var reported = require('gulp-diff').reporter:

gulp.task('smth', function () {
  gult.src('/a').pipe(diff('/b')).pipe(reporter());
});
```

So, I've changed the interface of module a bit to conform that style :)
