### PR TITLE
Add 'fail' and 'quiet' options

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,20 +27,7 @@ gulp.task('js-beautify', function() {
       mode: 'VERIFY_AND_WRITE'
     }))
     .pipe(diff(/* 'target directory to diff against', defaults to diff against original source file */))
-    .pipe(diffReporter())
-    .on('data', function(data) {
-      if (data.diff && Object.keys(data.diff).length) {
-        // record that there have been errors
-        gulp.fail = true;
-      }
-    });
-});
-
-process.on('exit', function() {
-  if (gulp.fail) {
-    // return non-zero exit code
-    process.exit(1);
-  }
+    .pipe(diffReporter({ fail: true }));
 });
 
 ```

--- a/index.js
+++ b/index.js
@@ -56,8 +56,13 @@ exports.reporter = function reporter(opts) {
   opts = opts || {};
   return through2.obj(function(file, enc, cb) {
     if (file.diff && Object.keys(file.diff).length) {
-      console.log('\n' + clc.underline(file.path), '\n');
-      console.log(file.diff.map(formatLine).join(''));
+      if (!opts.quiet) {
+        console.log('\n' + clc.underline(file.path), '\n');
+        console.log(file.diff.map(formatLine).join(''));
+      }
+      if (opts.fail) {
+        this.emit('error', pluginError('Files differ'));
+      }
     }
     return cb(null, file);
   });


### PR DESCRIPTION
Fairly self-explanatory.

This is my use case:

``` js
gulp.task('prod.styles', function () {
  return gulp.src('src/styles/main.sass')
    .pipe($.rubySass())
    .pipe($.minifyCss())
    .pipe($.replace(/(background:.*?(left|center|right)) center/g, '$1'))
    .pipe($.cssbeautify())
    .pipe($.rename('main-before.css'))
    .pipe(gulp.dest('dist/prod/_styles/_verify'))
    .pipe($.uncss({ html: glob.sync('dist/prod/**/*.html') }))
    .pipe($.minifyCss())
    .pipe($.cssbeautify())
    .pipe($.diff.diff())
    .pipe($.rename('main-after.css'))
    .pipe(gulp.dest('dist/prod/_styles/_verify'))
    .pipe($.diff.reporter({ fail: true, quiet: true }))
    .on('error', function () {
      gutil.beep();
      var git = spawn('git', [
          'diff',
          '--color',
          '--no-index',
          '--patience',
          'dist/prod/_styles/_verify/main-before.css',
          'dist/prod/_styles/_verify/main-after.css'
        ]);
      git.stdout.pipe(process.stdout);
      git.stderr.pipe(process.stderr);
    })
    .pipe(prefixCss())
    .pipe($.minifyCss())
    .pipe($.rename('main.css'))
    .pipe(gulp.dest('dist/prod/_styles'));
});
```

Example output:

``` diff
[20:30:40] Starting 'prod.styles'...
[20:30:47] gulp-ruby-sass: directory
[20:30:48] gulp-ruby-sass: write main.css
diff --git a/dist/prod/_styles/_verify/main-before.css b/dist/prod/_styles/_verify/main-after.css
index 536e795..8d19957 100755
--- a/dist/prod/_styles/_verify/main-before.css
+++ b/dist/prod/_styles/_verify/main-after.css
@@ -1,6 +1,6 @@
 @charset "UTF-8";

-a,abbr,address,article,aside,body,dd,div,dl,dt,figure,footer,h1,h2,h3,header,html,li,nav,p,section,ul {
+a,address,article,aside,body,dd,div,dl,dt,figure,footer,h1,h2,h3,header,html,li,nav,p,section,ul {
     margin: 0;
     padding: 0;
     border: 0;
```
