### PR TITLE
remove gulp-util dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var diffLines = require('diff').diffLines;
 var clc = require('cli-color');
 var fs = require('fs');
 var path = require('path');
-var PluginError = require('gulp-util').PluginError;
+var PluginError = require('plugin-error');
 
 function pluginError(msg) {
   return new PluginError('gulp-diff', msg);

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "diff": "^2.0.2",
-    "gulp-util": "^3.0.6",
-    "through2": "^2.0.0",
     "cli-color": "^1.0.0",
-    "event-stream": "^3.1.5"
+    "diff": "^2.0.2",
+    "event-stream": "^3.1.5",
+    "plugin-error": "^1.0.1",
+    "through2": "^2.0.0"
   },
   "devDependencies": {
     "gulp": "^3.6.2",


### PR DESCRIPTION
Following the upgrade plan at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5 replace the gulp-util dependency with https://github.com/gulpjs/plugin-error

See https://github.com/creativelive/gulp-diff/issues/12